### PR TITLE
Fix safari spacing issue

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -13,12 +13,7 @@ export default class Log {
     const el = document.querySelector("#debug")
 
     if (el) {
-      let detailString = ""
-      if (detail) {
-        Object.values(detail).map(value => {
-          detailString = `${detailString.trim()} ${value.trim()}`
-        })
-      }
+      const detailString = Object.values(detail || []).join(" ")
 
       el.insertAdjacentHTML("afterbegin", `${message} - ${detailString}<br/>`)
     }

--- a/src/log.js
+++ b/src/log.js
@@ -16,7 +16,7 @@ export default class Log {
       let detailString = ""
       if (detail) {
         Object.values(detail).map(value => {
-          detailString = `${detailString} ${value}`
+          detailString = `${detailString.trim()} ${value.trim()}`
         })
       }
 


### PR DESCRIPTION
Safari was inserting an extra space in tests, preventing our regexs from working correctly.